### PR TITLE
Permit deprecated url parameter to be undefined.

### DIFF
--- a/mobile/src/main/scala/sri/mobile/components/WebView.scala
+++ b/mobile/src/main/scala/sri/mobile/components/WebView.scala
@@ -9,7 +9,7 @@ import sri.universal.components.EdgeInsets
 import scala.scalajs.js
 
 case class WebView(contentInset: js.UndefOr[EdgeInsets] = js.undefined,
-                   url: String,
+                   url: js.UndefOr[String] = js.undefined,
                    style: js.UndefOr[js.Any] = js.undefined,
                    javaScriptEnabled: js.UndefOr[Boolean] = js.undefined,
                    ref: js.UndefOr[WebViewM => _] = js.undefined,


### PR DESCRIPTION
According to [the official document](http://facebook.github.io/react-native/docs/webview.html#url), `url` is deprecated and using `source` instead is encouraged.
