### PR TITLE
Add a paramenter to onScroll function.

### DIFF
--- a/mobile-examples/src/main/scala/sri/mobile/examples/uiexplorer/components/ScrollViewExample.scala
+++ b/mobile-examples/src/main/scala/sri/mobile/examples/uiexplorer/components/ScrollViewExample.scala
@@ -3,6 +3,7 @@ package sri.mobile.examples.uiexplorer.components
 import sri.core.ElementFactory._
 import sri.core.ReactComponent
 import sri.mobile.examples.uiexplorer.{UIExample, UIExplorerBlock, UIExplorerPage}
+import sri.universal.ReactEvent
 import sri.universal.components._
 import sri.universal.styles.UniversalStyleSheet
 
@@ -32,7 +33,7 @@ object ScrollViewExample extends UIExample {
         ScrollView(style = styles.scrollView,
           contentInset = EdgeInsets(top = -50.0),
           scrollEventThrottle = 16,
-          onScroll = () => println(s"on Scroll!"))(
+          onScroll = (e: ReactEvent[ScrollEvent]) => println(s"on Scroll: (${e.nativeEvent.contentOffset.x}, ${e.nativeEvent.contentOffset.y})"))(
             THUMBS.++(THUMBS).zipWithIndex.map {
               case (u, i) => THUMB(u, key = i.toString)
             }
@@ -43,7 +44,7 @@ object ScrollViewExample extends UIExample {
           horizontal = true,
           scrollEventThrottle = 16,
           contentInset = EdgeInsets(top = -50.0),
-          onScroll = () => println(s"on Scroll!"))(
+          onScroll = (e: ReactEvent[ScrollEvent]) => println(s"on Scroll: (${e.nativeEvent.contentOffset.x}, ${e.nativeEvent.contentOffset.y})"))(
             THUMBS.++(THUMBS).zipWithIndex.map {
               case (u, i) => THUMB(u, key = i.toString)
             }

--- a/universal/src/main/scala/sri/universal/components/ScrollView.scala
+++ b/universal/src/main/scala/sri/universal/components/ScrollView.scala
@@ -2,7 +2,7 @@ package sri.universal.components
 
 import chandu0101.macros.tojs.JSMacro
 import sri.core.{React, ReactElement, ReactNode}
-import sri.universal.ReactUniversal
+import sri.universal.{ReactEvent, ReactUniversal}
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.ScalaJSDefined
@@ -22,7 +22,7 @@ case class ScrollView(zoomScale: js.UndefOr[Int] = js.undefined,
                       centerContent: js.UndefOr[Boolean] = js.undefined,
                       removeClippedSubviews: js.UndefOr[Boolean] = js.undefined,
                       ref: js.UndefOr[ScrollViewM => _] = js.undefined,
-                      onScroll: js.UndefOr[() => Unit] = js.undefined,
+                      onScroll: js.UndefOr[(ReactEvent[ScrollEvent]) => Unit] = js.undefined,
                       scrollEventThrottle: js.UndefOr[Int] = js.undefined,
                       throttleScrollCallbackMS: js.UndefOr[Int] = js.undefined,
                       showsHorizontalScrollIndicator: js.UndefOr[Boolean] = js.undefined,
@@ -81,3 +81,43 @@ trait ScrollViewM extends js.Object {
   def scrollTo(position : ScrollPosition): Unit = js.native
 }
      
+@js.native
+trait ScrollEvent extends js.Object {
+
+  val contentInset: ContentInset = js.native
+
+  val contentOffset: ContentOffset = js.native
+
+  val layoutMeasurement: Size2d = js.native
+
+  val contentSize: Size2d = js.native
+
+  val zoomScale: Double = js.native
+}
+
+@js.native
+trait ContentInset extends js.Object {
+
+  val top: Double = js.native
+
+  val left: Double = js.native
+
+  val right: Double = js.native
+
+  val bottom: Double = js.native
+}
+@js.native
+trait ContentOffset extends js.Object {
+
+  val x: Double = js.native
+
+  val y: Double = js.native
+}
+
+@js.native
+trait Size2d extends js.Object {
+
+  val width: Double = js.native
+
+  val height: Double = js.native
+}


### PR DESCRIPTION
Although even [the official document](https://facebook.github.io/react-native/docs/scrollview.html#onscroll) does not mention it explicitly, onScroll is called with an argument passed to it.

https://github.com/facebook/react-native/blob/a53d0f99ddaefc117c134b9b8dde351d676abad8/React/Views/RCTScrollView.m#L71
https://github.com/facebook/react-native/blob/a53d0f99ddaefc117c134b9b8dde351d676abad8/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java#L121

It would be preferable if we can make use of this event object. For example, we might want to track the position of a displaying content within a scroll view.
